### PR TITLE
[dotfiles-improvement] fix: add local vars in new-changelog and cd error check in import-wifi-credentials

### DIFF
--- a/zsh/functions/git-utils.zsh
+++ b/zsh/functions/git-utils.zsh
@@ -17,9 +17,9 @@ cherrypick-pr-to-branch() {
 
 # Helper function to create a new changelog for velero repos
 new-changelog() {
-    GH_LOGIN=$(gh pr view --json author --jq .author.login 2> /dev/null)
-    GH_PR_NUMBER=$(gh pr view --json number --jq .number 2> /dev/null)
-    CHANGELOG_BODY="$(gh pr view --json title --jq .title)"
+    local GH_LOGIN=$(gh pr view --json author --jq .author.login 2> /dev/null)
+    local GH_PR_NUMBER=$(gh pr view --json number --jq .number 2> /dev/null)
+    local CHANGELOG_BODY="$(gh pr view --json title --jq .title)"
     if [ "$GH_LOGIN" = "" ]; then \
         echo "branch does not have PR or cli not logged in, try 'gh auth login' or 'gh pr create'"; \
         return 1; \

--- a/zsh/functions/migrate-laptop.zsh
+++ b/zsh/functions/migrate-laptop.zsh
@@ -467,7 +467,7 @@ import-wifi-credentials() {
     fi
     
     progress "Starting WiFi import..."
-    cd "$import_dir"
+    cd "$import_dir" || { error "Failed to cd into $import_dir"; return 1; }
     ./import-wifi.sh
 }
 


### PR DESCRIPTION
…entials

- Declare GH_LOGIN, GH_PR_NUMBER, CHANGELOG_BODY as local in new-changelog() to prevent leaking variables into the global shell environment
- Add error check after cd in import-wifi-credentials() to fail fast if the import directory cannot be entered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the laptop migration utility to properly report and halt execution when directory access fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaovilai/dotfiles/pull/14)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->