### PR TITLE
fix: add local declaration for attempts in reconnect_wifi

### DIFF
--- a/zsh/functions/aa-inflight-wifi.zsh
+++ b/zsh/functions/aa-inflight-wifi.zsh
@@ -95,7 +95,7 @@ aa-inflight-wifi() {
 
         # Wait for internet to become available
         echo "Waiting for internet connection (complete the login in your browser)..."
-        attempts=0
+        local attempts=0
         while ! check_internet && [[ $attempts -lt $MAX_ATTEMPTS ]]; do
             sleep $CHECK_INTERVAL
             ((attempts++))


### PR DESCRIPTION
## Summary

- Add `local` keyword to `attempts=0` in `reconnect_wifi()` inside `aa-inflight-wifi.zsh` to prevent variable leaking to global scope

Closes #34
Closes #35

The original agentic workflow (run [25938813418](https://github.com/kaovilai/dotfiles/actions/runs/25938813418)) correctly identified this issue but failed to create the PR due to a [gh-aw shallow clone bug](https://github.com/github/gh-aw/issues/32467) — the `safe_outputs` job uses `fetch-depth: 1` which can't satisfy bundle prerequisites referencing older commits.

> [!Note]
> Responses generated with Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of inflight WiFi connectivity by fixing a variable scoping issue in the retry logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaovilai/dotfiles/pull/37)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->