### PR TITLE
test: trigger gh-aw prerelease compile

### DIFF
--- a/.github/workflows/claude-code-review.md
+++ b/.github/workflows/claude-code-review.md
@@ -36,3 +36,4 @@ Use the pull request metadata, changed files, repository contents, and available
 Follow repository conventions from `CLAUDE.md` when relevant.
 
 Only add a comment when you find at least one specific, actionable issue worth flagging. If the changes look good, do not create a comment.
+If there are no code changes (e.g., only lock file updates), do not create a comment.


### PR DESCRIPTION
Test PR to verify gh-aw prerelease compile workflow auto-commits lock files to PR branch.

Ref: https://github.com/github/gh-aw/issues/32467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code review workflow to skip review comments for pull requests containing only non-code changes, such as lockfile updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kaovilai/dotfiles/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->