### PR TITLE
fix: bundle git-utils.zsh improvements

### DIFF
--- a/zsh/functions/git-utils.zsh
+++ b/zsh/functions/git-utils.zsh
@@ -25,9 +25,10 @@ cherrypick-pr-to-branch() {
 
 # Helper function to create a new changelog for velero repos
 new-changelog() {
-    local GH_LOGIN=$(gh pr view --json author --jq .author.login 2> /dev/null)
-    local GH_PR_NUMBER=$(gh pr view --json number --jq .number 2> /dev/null)
-    local CHANGELOG_BODY="$(gh pr view --json title --jq .title)"
+    local GH_LOGIN GH_PR_NUMBER CHANGELOG_BODY
+    GH_LOGIN=$(gh pr view --json author --jq .author.login 2> /dev/null)
+    GH_PR_NUMBER=$(gh pr view --json number --jq .number 2> /dev/null)
+    CHANGELOG_BODY=$(gh pr view --json title --jq .title 2> /dev/null)
     if [[ -z "$GH_LOGIN" ]]; then
         echo "branch does not have PR or cli not logged in, try 'gh auth login' or 'gh pr create'"
         return 1
@@ -64,13 +65,20 @@ go-mod-upgrade() {
 # Examples: GOTOOLCHAIN=go1.23.6 go-mod-upgrade-dirs "velero*" golang.org/x/oauth2@v0.27.0
 # Examples: GOTOOLCHAIN=go1.23.6 go-mod-upgrade-dirs "velero*" golang.org/x/crypto@v0.35.0 "gsed -i \"s/golang:1.22-bookworm/golang:1.23-bookworm/g\" Dockerfile && git add Dockerfile" CVE-2025-22869
 go-mod-upgrade-dirs() {
-    find . -type d -maxdepth 1 -name "$1" -exec sh -c "cd {} && pwd && \
-        git fetch upstream && (git checkout upstream/main || git checkout upstream/master || git checkout upstream/oadp-dev) && \
-        (git checkout -b $2 || git checkout $2) && \
-        go get $2 && go mod tidy && git add go.mod go.sum && \
-        sh -c \"$3\" && \
-        git commit -sm \"$4$2\" && \
-        gh pr create --web --title \"$4$2\"" \;
+    if ! command -v go &>/dev/null; then
+        echo "❌ go not found. Install it with: brew install go"
+        return 1
+    fi
+    find . -type d -maxdepth 1 -name "$1" -exec sh -c '
+        dir="$1" pkg="$2" extra_cmd="$3" prefix="$4"
+        cd "$dir" && pwd &&
+        git fetch upstream && (git checkout upstream/main || git checkout upstream/master || git checkout upstream/oadp-dev) &&
+        (git checkout -b "$pkg" || git checkout "$pkg") &&
+        go get "$pkg" && go mod tidy && git add go.mod go.sum &&
+        sh -c "$extra_cmd" &&
+        git commit -sm "${prefix}${pkg}" &&
+        gh pr create --web --title "${prefix}${pkg}"
+    ' _ {} "$2" "$3" "$4" \;
 }
 
 # execute commands in dirs matched by find . -type d -maxdepth 1 -name "<$1>"
@@ -78,7 +86,13 @@ go-mod-upgrade-dirs() {
 # Examples: exec-dirs "velero*" golang.org/x/oauth2@v0.27.0 "pwd && pwd"
 # Examples: exec-dirs "velero*" golang.org/x/oauth2@v0.27.0 "snyk test"
 exec-dirs() {
-    find . -type d -maxdepth 1 -name "$1" -exec sh -c "cd {} && pwd && git fetch upstream && (git checkout upstream/main || git checkout upstream/master || git checkout upstream/oadp-dev) && (git checkout -b $2 || git checkout $2) && sh -c \"$3\"" \;
+    find . -type d -maxdepth 1 -name "$1" -exec sh -c '
+        dir="$1" branch="$2" cmd="$3"
+        cd "$dir" && pwd &&
+        git fetch upstream && (git checkout upstream/main || git checkout upstream/master || git checkout upstream/oadp-dev) &&
+        (git checkout -b "$branch" || git checkout "$branch") &&
+        sh -c "$cmd"
+    ' _ {} "$2" "$3" \;
 }
 
 # Improved version of exec-dirs-ds and exec-dirs-ds-echo with better error handling,


### PR DESCRIPTION
## Summary
- Split `local` declaration from command substitution in `new-changelog` to avoid masked exit codes
- Add `command -v go` guard to `go-mod-upgrade-dirs`
- Harden `find -exec sh -c` injection risk in `go-mod-upgrade-dirs` and `exec-dirs`

Closes #138
Closes #142

Combines: #150, #156, #159

> [!Note]
> Responses generated with Claude