### PR TITLE
🔒 Fix eval() vulnerability in verify-migration

### DIFF
--- a/zsh/functions/migrate-laptop.zsh
+++ b/zsh/functions/migrate-laptop.zsh
@@ -522,11 +522,11 @@ list-wifi-networks() {
 
 _verify_check() {
     local name="$1"
-    local command="$2"
+    shift
 
     (( _verify_checks_total++ ))
 
-    if eval "$command" >/dev/null 2>&1; then
+    if "$@" >/dev/null 2>&1; then
         success "$name"
         (( _verify_checks_passed++ ))
     else
@@ -542,21 +542,25 @@ verify-migration() {
     local _verify_checks_passed=0
     local _verify_checks_total=0
     
+    _check_docker() { command_exists docker || command_exists podman; }
+    _check_ssh_key() { [[ -f ~/.ssh/id_ed25519 ]] || [[ -f ~/.ssh/id_rsa ]]; }
+    _check_dotfiles() { [[ -f ~/.zshrc ]] && grep -q 'dotfiles' ~/.zshrc; }
+
     # Run checks
-    _verify_check "Homebrew" "command_exists brew"
-    _verify_check "Git" "command_exists git"
-    _verify_check "GitHub CLI" "command_exists gh"
-    _verify_check "Docker/Podman" "command_exists docker || command_exists podman"
-    _verify_check "OpenShift CLI" "command_exists oc"
-    _verify_check "VS Code" "command_exists code"
-    _verify_check "GPG" "command_exists gpg"
-    _verify_check "SSH directory" "[[ -d ~/.ssh ]]"
-    _verify_check "SSH key exists" "[[ -f ~/.ssh/id_ed25519 ]] || [[ -f ~/.ssh/id_rsa ]]"
-    _verify_check "Dotfiles linked" "[[ -f ~/.zshrc ]] && grep -q 'dotfiles' ~/.zshrc"
-    _verify_check "Secrets file" "[[ -f ~/secrets.zsh ]]"
-    _verify_check "Go installed" "command_exists go"
-    _verify_check "Node installed" "command_exists node"
-    _verify_check "Python installed" "command_exists python3"
+    _verify_check "Homebrew" command_exists brew
+    _verify_check "Git" command_exists git
+    _verify_check "GitHub CLI" command_exists gh
+    _verify_check "Docker/Podman" _check_docker
+    _verify_check "OpenShift CLI" command_exists oc
+    _verify_check "VS Code" command_exists code
+    _verify_check "GPG" command_exists gpg
+    _verify_check "SSH directory" test -d "$HOME/.ssh"
+    _verify_check "SSH key exists" _check_ssh_key
+    _verify_check "Dotfiles linked" _check_dotfiles
+    _verify_check "Secrets file" test -f "$HOME/secrets.zsh"
+    _verify_check "Go installed" command_exists go
+    _verify_check "Node installed" command_exists node
+    _verify_check "Python installed" command_exists python3
     
     echo ""
     echo "Checks passed: $_verify_checks_passed/$_verify_checks_total"


### PR DESCRIPTION
🎯 **What:** Removed the vulnerable `eval "$command"` pattern from the `_verify_check` function inside `zsh/functions/migrate-laptop.zsh` and refactored call sites.
⚠️ **Risk:** The previous `eval "$command"` approach evaluated arbitrary strings as bash commands. If any component inside the string was improperly escaped or provided by an untrusted source, this could lead to an arbitrary code execution vulnerability.
🛡️ **Solution:** Altered the `_verify_check` signature to accept variable arguments. By `shift`ing the label and directly executing `"$@"`, we avoid string interpolation and command evaluation via `eval`. For checks utilizing complex shell logic (such as pipelines, short-circuits `||`, or test constructs like `[[ ]]`), safe, local helper functions were created (e.g. `_check_docker` and `_check_dotfiles`) which are then natively executed.

---
*PR created automatically by Jules for task [14444529775940461159](https://jules.google.com/task/14444529775940461159) started by @kaovilai*